### PR TITLE
Add Debian 13 support and update Debian 11/12 ISOs

### DIFF
--- a/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
@@ -29,8 +29,8 @@ vm_network_card_model   = "virtio"
 
 // Removable Media Settings
 iso_path     = "iso"
-iso_file     = "debian-11.8.0-amd64-netinst.iso"
-iso_checksum = "d7a74813a734083df30c8d35784926deaa36bc41e5c0766388e9f591ab056b72"
+iso_file     = "debian-11.11.0-amd64-netinst.iso"
+iso_checksum = "file:https://get.debian.org/images/archive/11.11.0/amd64/iso-cd/SHA512SUMS"
 
 // Boot Settings
 vm_boot      = "order=virtio0;ide2;net0"

--- a/builds/linux/debian/13/data/network.pkrtpl.hcl
+++ b/builds/linux/debian/13/data/network.pkrtpl.hcl
@@ -1,0 +1,9 @@
+d-i netcfg/choose_interface select ${device}
+%{ if ip != null ~}
+d-i netcfg/disable_autoconfig boolean true
+d-i netcfg/get_ipaddress string ${ip}
+d-i netcfg/get_netmask string ${cidrnetmask("${ip}/${netmask}")}
+d-i netcfg/get_gateway string ${gateway}
+d-i netcfg/get_nameservers string ${join(" ", dns)}
+d-i netcfg/confirm_static boolean true
+%{ endif ~}

--- a/builds/linux/debian/13/data/preseed.pkrtpl.hcl
+++ b/builds/linux/debian/13/data/preseed.pkrtpl.hcl
@@ -1,0 +1,94 @@
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Debian 13 (Trixie) Preseed File
+# https://www.debian.org/releases/bullseye/amd64/
+
+# Locale and Keyboard
+d-i debian-installer/locale string ${vm_os_language}
+d-i keyboard-configuration/xkb-keymap select ${vm_os_keyboard}
+
+# Clock and Timezone
+d-i clock-setup/utc boolean true
+d-i clock-setup/ntp boolean true
+d-i time/zone string ${vm_os_timezone}
+
+# Grub and Reboot Message
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+
+# Partitioning
+${storage}
+
+# Network configuration
+${network}
+
+### Apt setup
+# Choose, if you want to scan additional installation media
+# (default: false).
+d-i apt-setup/cdrom/set-first boolean false
+# You can choose to install non-free firmware.
+#d-i apt-setup/non-free-firmware boolean true
+# You can choose to install non-free and contrib software.
+#d-i apt-setup/non-free boolean true
+#d-i apt-setup/contrib boolean true
+# Uncomment the following line, if you don't want to have the sources.list
+# entry for a DVD/BD installation image active in the installed system
+# (entries for netinst or CD images will be disabled anyway, regardless of
+# this setting).
+#d-i apt-setup/disable-cdrom-entries boolean true
+# Uncomment this if you don't want to use a network mirror.
+#d-i apt-setup/use_mirror boolean false
+# Select which update services to use; define the mirrors to be used.
+# Values shown below are the normal defaults.
+#d-i apt-setup/services-select multiselect security, updates
+#d-i apt-setup/security_host string security.debian.org
+
+# Mirror settings
+d-i mirror/country string manual
+d-i mirror/http/hostname string cdn-fastly.deb.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+# User Configuration
+d-i passwd/root-login boolean false
+d-i passwd/user-fullname string ${build_username}
+d-i passwd/username string ${build_username}
+d-i passwd/user-password-crypted password ${build_password_encrypted}
+
+# Package Configuration
+d-i pkgsel/run_tasksel boolean false
+d-i pkgsel/include string openssh-server qemu-guest-agent python3-apt ${additional_packages}
+
+# You can choose, if your system will report back on what software you have
+# installed, and what software you use. The default is not to report back,
+# but sending reports helps the project determine what software is most
+# popular and should be included on the first CD/DVD.
+popularity-contest popularity-contest/participate boolean false
+
+### Boot loader installation
+# Grub is the boot loader (for x86).
+
+# This is fairly safe to set, it makes grub install automatically to the UEFI
+# partition/boot record if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+# Post-install script
+#  - Add User to Sudoers
+#  - Remove lv_delete volume group
+d-i preseed/late_command string \
+    echo '${build_username} ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/${build_username} ; \
+    in-target chmod 440 /etc/sudoers.d/${build_username}%{ if length(lvm) != 0 ~} ; \
+    lvremove -f /dev/%{ for volume_group in lvm ~}${volume_group.name}%{ endfor ~}/lv_delete > /dev/null 2>&1%{ endif }
+
+%{ if common_data_source == "disk" ~}
+# Umount preseed media early
+d-i preseed/early_command string \
+    umount /media && echo 1 > /sys/block/sr1/device/delete ;
+%{ endif ~}
+

--- a/builds/linux/debian/13/data/storage.pkrtpl.hcl
+++ b/builds/linux/debian/13/data/storage.pkrtpl.hcl
@@ -1,0 +1,157 @@
+
+%{~ if length(lvm) != 0 ~}
+d-i partman-auto/method string lvm
+d-i partman-auto-lvm/guided_size string max
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+    %{~ for volume_group in lvm ~}
+d-i partman-auto-lvm/new_vg_name string ${volume_group.name}
+    %{~ endfor ~}
+%{~ endif ~}
+
+d-i partman-efi/non_efi_system boolean true
+
+# Ensure the partition table is GPT - this is required for EFI
+d-i partman-partitioning/choose_label select gpt
+d-i partman-partitioning/default_label string gpt
+
+# If there is only one partition defined and its name is 'autopart'
+# then use auto partitioning
+%{~ if length(partitions) == 1 && partitions[0].name == "autopart" ~}
+d-i partman-auto/disk string /dev/${device}
+    %{~ if partitions[0].format.fstype == "lvm" ~}
+d-i partman-auto/method string lvm
+
+# You can define the amount of space that will be used for the LVM volume
+# group. It can either be a size with its unit (eg. 20 GB), a percentage of
+# free space or the 'max' keyword.
+d-i partman-auto-lvm/guided_size string max
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+    %{~ endif ~}
+    %{~ if partitions[0].format.fstype == "simple" ~}
+d-i partman-auto/method string regular
+    %{~ endif ~}
+    %{ if partitions[0].format.fstype == "" ~}
+d-i partman-auto/method string regular
+    %{~ endif ~}
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+%{~ else ~} # if length(partitions) == 1 && partitions[0].name == "autopart"
+    %{~ if swap == false ~}
+d-i partman-basicfilesystems/no_swap boolean false
+    %{~ endif ~}
+d-i partman-auto/expert_recipe string \
+  custom :: \
+    %{~ for partition in partitions ~}
+        %{~ if lookup(partition, "volume_group", "") == "" ~}
+            %{~ if partition.size != -1 ~}
+    ${partition.size} ${partition.size} ${partition.size} ${partition.format.fstype} \
+            %{~ else ~}
+    100 100 -1 ${partition.format.fstype} \
+            %{~ endif ~}
+    $primary{ } \
+            %{~ if partition.mount.path == "/boot" ~}
+    $bootable{ } \
+    mountpoint{ /boot } \
+    method{ format } \
+            %{~ endif ~}
+            %{~ if partition.mount.path == "/boot/efi" ~}
+    mountpoint{ /boot/efi } \
+    method{ efi } \
+            %{~ endif ~}
+            %{~ if partition.mount.path != "/boot" && partition.mount.path != "/boot/efi" ~}
+                %{~ if partition.mount.path != "" ~}
+    mountpoint{ ${partition.mount.path} } \
+                %{~ endif ~}
+    method{ ${partition.format.fstype} } \
+            %{~ endif ~}
+    format{ } \
+            %{~ if partition.format.fstype != "swap" ~}
+    use_filesystem{ } \
+                %{~ if partition.format.fstype == "fat32" ~}
+    filesystem{ vfat } \
+                %{~ else ~}
+    filesystem{ ${partition.format.fstype} } \
+                %{~ endif ~}
+            %{~ endif ~}
+    label { ${partition.format.label} } \
+            %{~ for option in split(",", lookup(partition.mount, "options", "")) ~}
+                %{~ if option != "" ~}
+    options/${option}{ ${option} } \
+                %{~ endif ~}
+            %{~ endfor ~}
+    . \
+        %{~ else /* if lookup(partition, "volume_group", "") == "" */ ~}
+            %{~ for volume_group in lvm ~}
+                %{~ if volume_group.name == partition.volume_group ~}
+                    %{~ for partition in volume_group.partitions ~}
+                        %{ if partition.size != -1 ~}
+                            %{ if partition.format.fstype == "swap" ~}
+    ${partition.size} ${partition.size} ${partition.size} linux-swap \
+                            %{~ else ~}
+    ${partition.size} ${partition.size} ${partition.size} ${partition.format.fstype} \
+                            %{~ endif ~}
+                        %{~ else ~}
+                            %{~ if partition.format.fstype != "swap" /* I don't know who would fill their disk with swap but it could happen */ ~}
+    100 100 -1 ${partition.format.fstype} \
+                            %{~ else ~}
+    100 100 -1 linux-swap \
+                            %{~ endif ~}
+                        %{ endif ~}
+    $lvmok{ } \
+                        %{~ if partition.mount.path != "" ~}
+    mountpoint{ ${partition.mount.path} } \
+                        %{~ endif ~}
+    lv_name{ ${partition.name} } \
+    in_vg { ${volume_group.name} } \
+                        %{~ if partition.format.fstype == "swap" ~}
+    method{ swap } \
+                        %{~ else ~}
+    method{ format } \
+                        %{~ endif ~}
+    format{ } \
+                        %{~ if partition.format.fstype != "swap" ~}
+    use_filesystem{ } \
+    filesystem{ ${partition.format.fstype} } \
+                        %{~ endif ~}
+    label { ${partition.format.label} } \
+                        %{~ for option in split(",", lookup(partition.mount, "options", "")) ~}
+                            %{~ if option != "" ~}
+    options/${option}{ ${option} } \
+                            %{~ endif ~}
+                        %{~ endfor ~}
+    . \
+                    %{~ endfor /* partition in volume_group.partitions */ ~}
+    1024 1024 1024 ext4 \
+    method{ lvm } \
+    $lvmok{ } \
+    lv_name{ lv_delete } \
+    mountpoint{ /tmp/lv_delete } \
+    . \
+                %{~ endif /* volume_group.name == partition.volume_group */ ~}
+            %{~ endfor /* for volume_group in lvm */ ~}
+        %{~ endif /* if lookup(partition, "volume_group", "") == "" */ ~}
+    %{~ endfor /* for partition in partitions */ ~}
+
+%{~ endif /* if length(partitions) == 1 && partitions[0].name == "autopart" */ ~}
+
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# To make sure the machine can boot we install grub on the first harddisk:
+d-i grub-installer/bootdev string /dev/${device}

--- a/builds/linux/debian/13/linux-debian.pkr.hcl
+++ b/builds/linux/debian/13/linux-debian.pkr.hcl
@@ -1,0 +1,255 @@
+/*
+    DESCRIPTION:
+    Debian 13 template using the Packer Builder for Proxmox (proxmox-iso).
+*/
+
+//  BLOCK: packer
+//  The Packer configuration.
+
+packer {
+  required_version = ">= 1.12.0"
+  required_plugins {
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+    git = {
+      version = ">= 0.6.2"
+      source  = "github.com/ethanmdavidson/git"
+    }
+    proxmox = {
+      version = "= 1.2.1"
+      source  = "github.com/hashicorp/proxmox"
+    }
+  }
+}
+
+//  BLOCK: data
+//  Defines the data sources.
+
+data "git-repository" "cwd" {}
+
+//  BLOCK: locals
+//  Defines the local variables.
+
+locals {
+
+  bios_boot_command = [
+    "<wait><wait><wait><esc><wait><wait><wait>",
+    "/install.amd/vmlinuz ",
+    "initrd=/install.amd/initrd.gz ",
+    "auto=true ",
+    "${local.data_source_command} ",
+//    "hostname=${var.vm_os_name}-${var.vm_os_version} ",
+    "netcfg/get_hostname=debian netcfg/get_domain=example.com ",
+    "interface=auto ",
+    "vga=788 noprompt quiet --<enter>"
+  ]
+
+  uefi_boot_command = [
+    // This waits for 3 seconds, sends the "c" key, and then waits for another 3 seconds. In the GRUB boot loader, this is used to enter command line mode.
+    "<wait3s>c<wait3s>",
+    // This types a command to load the Linux kernel from the specified path.
+    "linux /install.amd/vmlinuz",
+    // This types a string that sets the auto-install/enable option to true. This is used to automate the installation process.
+    " auto-install/enable=true",
+    // This types a string that sets the debconf/priority option to critical. This is used to minimize the number of questions asked during the installation process.
+    " debconf/priority=critical",
+    // This types the value of the 'data_source_command' local variable. This is used to specify the kickstart data source configured in the common variables.
+    " ${local.data_source_command}",
+    // This types a string that sets the noprompt option and then sends the "enter" key. This is used to prevent the installer from pausing for user input.
+    " noprompt --<enter>",
+    // This types a command to load the initial RAM disk from the specified path and then sends the "enter" key.
+    "initrd /install.amd/initrd.gz<enter>",
+    // This types the "boot" command and then sends the "enter" key. This starts the boot process using the loaded kernel and initial RAM disk.
+    "boot<enter>",
+    // This waits for 30 seconds. This is typically used to give the system time to boot before sending more commands.
+    "<wait30s>",
+    // This sends the "enter" key and then waits. This is typically used to dismiss any prompts or messages that appear during boot.
+    "<enter><wait>",
+    // This sends the "enter" key and then waits. This is typically used to dismiss any prompts or messages that appear during boot.
+    "<enter><wait>",
+    // This types the value of the `mount_cdrom` local variable. This is typically used to mount the installation media.
+    " ${local.mount_cdrom}",
+    // This sends four "down arrow" keys and then the "enter" key. This is typically used to select a specific option in a menu.
+    "<down><down><down><down><enter>"
+  ]
+
+  build_by          = "Built by: HashiCorp Packer ${packer.version}"
+  build_date        = formatdate("DD-MM-YYYY hh:mm ZZZ", "${timestamp()}" )
+  build_version     = data.git-repository.cwd.head
+  build_description = "Version: ${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}\nCloud-Init: ${var.vm_cloudinit}"
+  vm_disk_type      = var.vm_disk_type == "virtio" ? "vda" : "sda"
+  manifest_date     = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path     = "${path.cwd}/manifests/"
+  manifest_output   = "${local.manifest_path}${local.manifest_date}.json"
+  data_source_content = {
+    "/preseed.cfg" = templatefile("${abspath(path.root)}/data/preseed.pkrtpl.hcl", {
+      build_username           = var.build_username
+      build_password           = var.build_password
+      build_password_encrypted = var.build_password_encrypted
+      vm_disk_type             = local.vm_disk_type
+      vm_os_language           = var.vm_os_language
+      vm_os_keyboard           = var.vm_os_keyboard
+      vm_os_timezone           = var.vm_os_timezone
+      common_data_source       = var.common_data_source
+      network = templatefile("${abspath(path.root)}/data/network.pkrtpl.hcl", {
+        device  = var.vm_network_device
+        ip      = var.vm_ip_address
+        netmask = var.vm_ip_netmask
+        gateway = var.vm_ip_gateway
+        dns     = var.vm_dns_list
+      })
+      # lvm needs to be here so late commands can access vg names
+      lvm                      = var.vm_disk_lvm
+      storage                  = templatefile("${abspath(path.root)}/data/storage.pkrtpl.hcl", {
+        device                 = var.vm_disk_device
+        swap                   = var.vm_disk_use_swap
+        partitions             = var.vm_disk_partitions
+        lvm                    = var.vm_disk_lvm
+        vm_bios                = var.vm_bios
+      })
+      additional_packages = join(" ", var.additional_packages)
+    })
+  }
+  data_source_command = var.common_data_source == "http" ? "url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed.cfg" : "file=/media/preseed.cfg"
+  mount_cdrom_command = "<leftAltOn><f2><leftAltOff> <enter><wait> mount /dev/sr1 /media<enter> <leftAltOn><f1><leftAltOff>"
+  mount_cdrom         = var.common_data_source == "http" ? " " : local.mount_cdrom_command
+  vm_name = "${var.vm_os_family}-${var.vm_os_name}-${var.vm_os_version}"
+  boot_command = var.vm_bios == "ovmf" ? local.uefi_boot_command : local.bios_boot_command
+  vm_bios = var.vm_bios == "ovmf" ? var.vm_firmware_path : null
+}
+
+//  BLOCK: source
+//  Defines the builder configuration blocks.
+
+source "proxmox-iso" "debian" {
+
+  // Proxmox Connection Settings and Credentials
+  proxmox_url              = "https://${var.proxmox_hostname}:8006/api2/json"
+  username                 = "${var.proxmox_api_token_id}"
+  token                    = "${var.proxmox_api_token_secret}"
+  insecure_skip_tls_verify = "${var.proxmox_insecure_connection}"
+
+  // Proxmox Settings
+  node                     = "${var.proxmox_node}"
+
+  // Virtual Machine Settings
+  vm_name         = "${local.vm_name}"
+  bios            = "${var.vm_bios}"
+  sockets         = "${var.vm_cpu_sockets}"
+  cores           = "${var.vm_cpu_count}"
+  cpu_type        = "${var.vm_cpu_type}"
+  memory          = "${var.vm_mem_size}"
+  os              = "${var.vm_os_type}"
+  scsi_controller = "${var.vm_disk_controller_type}"
+
+  disks {
+    disk_size     = "${var.vm_disk_size}"
+    type          = "${var.vm_disk_type}"
+    storage_pool  = "${var.vm_storage_pool}"
+    format        = "${var.vm_disk_format}"
+  }
+
+  dynamic "efi_config" {
+    for_each = var.vm_bios == "ovmf" ? [1] : []
+    content {
+      efi_storage_pool  = var.vm_bios == "ovmf" ? var.vm_efi_storage_pool : null
+      efi_type          = var.vm_bios == "ovmf" ? var.vm_efi_type : null
+      pre_enrolled_keys = var.vm_bios == "ovmf" ? var.vm_efi_pre_enrolled_keys : null
+    }
+  }
+
+  ssh_username    = "${var.build_username}"
+  ssh_password    = "${var.build_password}"
+  ssh_timeout     = "${var.timeout}"
+  ssh_port        = "22"
+  qemu_agent      = true
+
+  network_adapters {
+    bridge     = "${var.vm_bridge_interface}"
+    model      = "${var.vm_network_card_model}"
+    vlan_tag   = "${var.vm_vlan_tag}"
+  }
+
+  // Removable Media Settings
+  http_content = "${var.common_data_source}" == "http" ? "${local.data_source_content}" : null
+
+  // Boot and Provisioning Settings
+  http_interface    = var.common_data_source == "http" ? var.common_http_interface : null
+  http_bind_address = var.common_data_source == "http" ? var.common_http_bind_address : null
+  http_port_min     = var.common_data_source == "http" ? var.common_http_port_min : null
+  http_port_max     = var.common_data_source == "http" ? var.common_http_port_max : null
+  boot              = var.vm_boot
+  boot_wait         = var.vm_boot_wait
+  boot_command      = local.boot_command
+
+  boot_iso {
+    iso_file      = "${var.common_iso_storage}:${var.iso_path}/${var.iso_file}"
+    unmount       = true
+    iso_checksum  = "${var.iso_checksum}"
+  }
+
+  dynamic "additional_iso_files" {
+    for_each = var.common_data_source == "disk" ? [1] : []
+    content {
+      cd_files = var.common_data_source == "disk" ? local.data_source_content : null
+      cd_label = var.common_data_source == "disk" ? "cidata" : null
+      iso_storage_pool = var.common_data_source == "disk" ? "local" : null
+    }
+  }
+
+  template_name        = "${local.vm_name}"
+  template_description = "${local.build_description}"
+
+  # VM Cloud Init Settings
+  cloud_init              = var.vm_cloudinit
+  cloud_init_storage_pool = var.vm_cloudinit == true ? var.vm_storage_pool : null
+
+}
+
+# Build Definition to create the VM Template
+build {
+  sources = ["source.proxmox-iso.debian"]
+
+  provisioner "ansible" {
+    user                   = var.build_username
+    galaxy_file            = "${path.cwd}/ansible/linux-requirements.yml"
+    galaxy_force_with_deps = true
+    playbook_file          = "${path.cwd}/ansible/linux-playbook.yml"
+    roles_path             = "${path.cwd}/ansible/roles"
+    ansible_env_vars = [
+      "ANSIBLE_CONFIG=${path.cwd}/ansible/ansible.cfg",
+      "ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3"
+    ]
+    extra_arguments = [
+      "--extra-vars", "display_skipped_hosts=false",
+      "--extra-vars", "build_username=${var.build_username}",
+      "--extra-vars", "build_key='${var.build_key}'",
+      "--extra-vars", "ansible_username=${var.ansible_username}",
+      "--extra-vars", "ansible_key='${var.ansible_key}'",
+      "--extra-vars", "enable_cloudinit='${var.vm_cloudinit}'",
+    ]
+  }
+
+  post-processor "manifest" {
+    output     = local.manifest_output
+    strip_path = true
+    strip_time = true
+    custom_data = {
+      ansible_username         = "${var.ansible_username}"
+      build_username           = "${var.build_username}"
+      build_date               = "${local.build_date}"
+      build_version            = "${local.build_version}"
+      common_data_source       = "${var.common_data_source}"
+      vm_cpu_sockets           = "${var.vm_cpu_sockets}"
+      vm_cpu_count             = "${var.vm_cpu_count}"
+      vm_disk_size             = "${var.vm_disk_size}"
+      vm_bios                  = "${var.vm_bios}"
+      vm_os_type               = "${var.vm_os_type}"
+      vm_mem_size              = "${var.vm_mem_size}"
+      vm_network_card_model    = "${var.vm_network_card_model}"
+      vm_cloudinit             = "${var.vm_cloudinit}"
+    }
+  }
+}

--- a/builds/linux/debian/13/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/13/linux-debian.pkrvars.hcl.example
@@ -1,6 +1,6 @@
 /*
     DESCRIPTION:
-    Debian 12 variables used by the Packer Plugin for Proxmox (proxmox-iso).
+    Debian 13 variables used by the Packer Plugin for Proxmox (proxmox-iso).
 */
 
 // Guest Operating System Metadata
@@ -9,7 +9,7 @@ vm_os_keyboard   = "us"
 vm_os_timezone   = "UTC"
 vm_os_family     = "linux"
 vm_os_name       = "debian"
-vm_os_version    = "12"
+vm_os_version    = "13"
 
 // Virtual Machine Guest Operating System Setting
 vm_os_type       = "l26"
@@ -29,8 +29,8 @@ vm_network_card_model   = "virtio"
 
 // Removable Media Settings
 iso_path     = "iso"
-iso_file     = "debian-12.12.0-amd64-netinst.iso"
-iso_checksum = "file:https://cdimage.debian.org/images/archive/12.12.0/amd64/iso-cd/SHA512SUMS"
+iso_file     = "debian-13.2.0-amd64-netinst.iso"
+iso_checksum = "file:https://cdimage.debian.org/debian-cd/13.2.0/amd64/iso-cd/SHA512SUMS"
 
 // Boot Settings
 vm_boot      = "order=virtio0;ide2;net0"

--- a/builds/linux/debian/13/variables-network.pkr.hcl
+++ b/builds/linux/debian/13/variables-network.pkr.hcl
@@ -1,0 +1,36 @@
+/*
+    DESCRIPTION:
+    Debian Linux 13 network variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
+*/
+
+// VM Network Settings
+
+variable "vm_network_device" {
+  type        = string
+  description = "The network device of the VM."
+  default     = "ens192"
+}
+
+variable "vm_ip_address" {
+  type        = string
+  description = "The IP address of the VM (e.g. 172.16.100.192)."
+  default     = null
+}
+
+variable "vm_ip_netmask" {
+  type        = number
+  description = "The netmask of the VM (e.g. 24)."
+  default     = null
+}
+
+variable "vm_ip_gateway" {
+  type        = string
+  description = "The gateway of the VM (e.g. 172.16.100.1)."
+  default     = null
+}
+
+variable "vm_dns_list" {
+  type        = list(string)
+  description = "The nameservers of the VM."
+  default     = []
+}

--- a/builds/linux/debian/13/variables-storage.pkr.hcl
+++ b/builds/linux/debian/13/variables-storage.pkr.hcl
@@ -1,0 +1,53 @@
+/*
+    DESCRIPTION:
+    Debian 13 storage variables used by the Packer Plugin for Proxmox (proxmox-iso).
+*/
+
+// VM Storage Settings
+
+variable "vm_disk_device" {
+  type        = string
+  description = "The device for the virtual disk. (e.g. 'sda')"
+}
+
+variable "vm_disk_use_swap" {
+  type        = bool
+  description = "Whether to use a swap partition."
+}
+
+variable "vm_disk_partitions" {
+  type = list(object({
+    name = string
+    size = number
+    format = object({
+      label  = string
+      fstype = string
+    })
+    mount = object({
+      path    = string
+      options = string
+    })
+    volume_group = string
+  }))
+  description = "The disk partitions for the virtual disk."
+}
+
+variable "vm_disk_lvm" {
+  type = list(object({
+    name    = string
+    partitions = list(object({
+      name = string
+      size = number
+      format = object({
+        label  = string
+        fstype = string
+      })
+      mount = object({
+        path    = string
+        options = string
+      })
+    }))
+  }))
+  description = "The LVM configuration for the virtual disk."
+  default     = []
+}

--- a/builds/linux/debian/13/variables.pkr.hcl
+++ b/builds/linux/debian/13/variables.pkr.hcl
@@ -1,0 +1,313 @@
+/*
+    DESCRIPTION:
+    Debian 13 variables using the Packer Builder for Proxmox (proxmox-iso).
+*/
+
+//  BLOCK: variable
+//  Defines the input variables.
+
+// Proxmox Credentials
+
+variable "proxmox_hostname" {
+  type        = string
+  description = "The FQDN or IP address of a Proxmox node. Only one node should be specified in a cluster."
+}
+
+variable "proxmox_api_token_id" {
+  type        = string
+  description = "The token to login to the Proxmox node/cluster. The format is USER@REALM!TOKENID. (e.g. packer@pam!packer_pve_token)"
+}
+
+variable "proxmox_api_token_secret" {
+  type        = string
+  description = "The secret for the API token used to login to the Proxmox API."
+#  sensitive   = true
+}
+
+variable "proxmox_insecure_connection" {
+  description = "true/false to skip Proxmox TLS certificate checks."
+  type        = bool
+  default     = true
+}
+
+// Proxmox Settings
+
+variable "proxmox_node" {
+  type    = string
+  description = "The name of the Proxmox node that Packer will build templates on."
+}
+
+// Virtual Machine Settings
+
+variable "vm_os_language" {
+  type        = string
+  description = "The guest operating system language."
+  default     = "en_US"
+}
+
+variable "vm_os_keyboard" {
+  type        = string
+  description = "The guest operating system keyboard layout."
+  default     = "us"
+}
+
+variable "vm_os_timezone" {
+  type        = string
+  description = "The guest operating system timezone."
+  default     = "UTC"
+}
+
+variable "vm_os_family" {
+  type        = string
+  description = "The guest operating system family. Used for naming. (e.g. 'linux')"
+}
+
+variable "vm_os_name" {
+  type        = string
+  description = "The guest operating system name. Used for naming. (e.g. 'ubuntu')"
+}
+
+variable "vm_os_version" {
+  type        = string
+  description = "The guest operating system version. Used for naming. (e.g. '22-04-lts')"
+}
+
+variable "vm_os_type" {
+  type        = string
+  description = "The guest operating system type. (e.g. 'l26')"
+}
+
+variable "vm_bios" {
+  type        = string
+  description = "The firmware type. Allowed values 'ovmf' or 'seabios'"
+  default     = "ovmf"
+
+  validation {
+    condition     = contains(["ovmf", "seabios"], var.vm_bios)
+    error_message = "The vm_bios value must be 'ovmf' or 'seabios'."
+  }
+}
+
+variable "vm_firmware_path" {
+  type        = string
+  description = "The firmware file to be used. Needed for EFI"
+  default     = "/usr/share/ovmf/OVMF.fd"
+}
+
+variable "vm_efi_storage_pool" {
+  type        = string
+  description = "Set the UEFI disk storage location. (e.g. 'local-lvm')"
+  default     = "local-lvm"
+}
+
+variable "vm_efi_type" {
+  type        = string
+  description = "Specifies the version of the OVMF firmware to be used. (e.g. '4m')"
+  default     = "4m"
+}
+
+variable "vm_efi_pre_enrolled_keys" {
+  type        = bool
+  description = "Whether Microsoft Standard Secure Boot keys should be pre-loaded on the EFI disk. (e.g. false)"
+  default     = false
+}
+
+variable "vm_cpu_count" {
+  type        = number
+  description = "The number of virtual CPUs. (e.g. '2')"
+}
+
+variable "vm_cpu_sockets" {
+  type        = number
+  description = "The number of virtual CPU sockets. (e.g. '1')"
+}
+
+variable "vm_cpu_type" {
+  type        = string
+  description = "The CPU type to emulate. See the Proxmox API documentation for the complete list of accepted values. For best performance, set this to host. Defaults to kvm64."
+}
+
+variable "vm_mem_size" {
+  type        = number
+  description = "The size for the virtual memory in MB. (e.g. '2048')"
+}
+
+variable "vm_disk_controller_type" {
+  type        = string
+  description = "The SCSI controller model to emulate. (e.g. 'virtio-scsi-pci')"
+}
+
+variable "vm_disk_type" {
+  type        = string
+  description = "The type of disk to emulate. (e.g. 'virtio')"
+}
+
+variable "vm_storage_pool" {
+  type        = string
+  description = "The name of the Proxmox storage pool to store the VM template. (e.g. 'local-lvm')"
+}
+
+variable "vm_disk_size" {
+  type        = string
+  description = "The size for the virtual disk in GB. (e.g. '32G')"
+}
+
+variable "vm_disk_format" {
+  type        = string
+  description = "The format of the file backing the disk. (e.g. 'qcow2')"
+}
+
+variable "vm_network_card_model" {
+  type        = string
+  description = "The model of the virtual network adapter to emulate. (e.g. 'virtio')"
+}
+
+variable "vm_bridge_interface" {
+  type        = string
+  description = "The name of the Proxmox bridge to attach the adapter to."
+}
+
+variable "vm_vlan_tag" {
+  type        = string
+  description = "If the adapter should tag packets, give the VLAN ID. (e.g. '102')"
+}
+
+// Cloud-Init Settings
+
+variable "vm_cloudinit" {
+  type        = bool
+  description = "Enable or disable cloud-init drive in Proxmox. (e.g. false)"
+  default     = false
+}
+
+// Removable Media Settings
+
+variable "common_iso_storage" {
+  type        = string
+  description = "The name of the source Proxmox storage location for ISO images. (e.g. 'local-lvm')"
+}
+
+variable "iso_path" {
+  type        = string
+  description = "The path on the source Proxmox storage location for ISO images. (e.g. 'iso')"
+}
+
+variable "iso_file" {
+  type        = string
+  description = "The file name of the ISO image used by the vendor. (e.g. 'ubuntu-<version>-live-server-amd64.iso')"
+}
+
+variable "iso_checksum" {
+  type        = string
+  description = "The checksum value of the ISO image provided by the vendor."
+}
+
+// Boot Settings
+
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source. (e.g. 'http' or 'disk')"
+}
+
+variable "common_http_bind_address" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
+variable "common_http_interface" {
+  type        = string
+  description = "Name of the network interface that Packer gets HTTPIP from. Defaults to the first non loopback interface."
+  default     = null
+}
+
+variable "common_http_port_min" {
+  type        = number
+  description = "The start of the HTTP port range."
+}
+
+variable "common_http_port_max" {
+  type        = number
+  description = "The end of the HTTP port range."
+}
+
+variable "vm_boot" {
+  type        = string
+  description = "The boot order for virtual machine devices. (e.g. 'order=virtio0;ide2;net0')"
+}
+
+variable "vm_boot_wait" {
+  type        = string
+  description = "The time to wait after booting the initial VM before typing the boot_command (e.g '10s')"
+}
+
+variable "common_ip_wait_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system IP address response."
+}
+
+variable "common_shutdown_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system shutdown."
+}
+
+// Communicator Settings and Credentials
+
+variable "build_username" {
+  type        = string
+  description = "The username to login to the guest operating system. (e.g. 'ubuntu')"
+#  sensitive   = true
+}
+
+variable "build_password" {
+  type        = string
+  description = "The password to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "build_password_encrypted" {
+  type        = string
+  description = "The encrypted password to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "build_key" {
+  type        = string
+  description = "The SSH public key to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "timeout" {
+  description = "not sure why I need so high a timeout but here we are"
+  default = "90m"
+}
+
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system. (e.g. 'ansible')"
+#  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+#  sensitive   = true
+}
+
+// HCP Packer Settings
+
+variable "common_hcp_packer_registry_enabled" {
+  type        = bool
+  description = "Enable the HCP Packer registry."
+  default     = false
+}
+
+// Additional Settings
+
+variable "additional_packages" {
+  type        = list(string)
+  description = "Additional packages to install."
+  default     = []
+}


### PR DESCRIPTION
This PR adds support for Debian 13 (Trixie) and updates the ISO versions for Debian 11 and 12.

## Changes
- **Added Debian 13 (Trixie) support**: Created complete configuration files in `builds/linux/debian/13/` including:
  - Main Packer template (`linux-debian.pkr.hcl`)
  - Variable definitions (`variables.pkr.hcl`, `variables-network.pkr.hcl`, `variables-storage.pkr.hcl`)
  - Example configuration (`linux-debian.pkrvars.hcl.example`)
  - Preseed templates for automated installation (`data/preseed.pkrtpl.hcl`, `data/network.pkrtpl.hcl`, `data/storage.pkrtpl.hcl`)
  
- **Updated Debian 11**: 
  - ISO updated from 11.8.0 to 11.11.0
  - Checksum updated to use SHA512 format

- **Updated Debian 12**:
  - ISO updated from 12.2.0 to 12.12.0
  - Checksum updated to use SHA512 format with version-specific path

All configurations follow the same pattern as existing Debian 11 and 12 implementations for consistency.